### PR TITLE
Update gulpfile.js.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,36 +1,69 @@
-const CI = process.env.CI === 'true';
+'use strict';
 
 const gulp = require('gulp');
-const mocha = require('gulp-mocha');
-const watch = require('gulp-watch');
-const batch = require('gulp-batch');
-const semistandard = require('gulp-semistandard');
-const runSequence = require('run-sequence');
 
-const sources = ['main.js', './lib/**/*.js'];
-const tests = ['./test/*.test.js'];
+// Are we running within continuous integration?
+const CI = process.env.CI === 'true';
 
-gulp.task('test', function (cb) {
-  runSequence(['tests', 'semistandard'], cb);
+// File globs.
+const entrypoint = require('./package.json')['main'];
+const globs = {
+  sources: [entrypoint, 'lib/**/*.js'],
+  tests: ['test/**/*.test.js'],
+  testsSetup: ['./test/setup.js']
+};
+const all = Array.prototype.concat.apply([], Object.keys(globs).map(x => globs[x]));
+
+// Default meta-task.
+gulp.task('default', ['test']);
+
+// Test meta-task.
+const runSequence = require('run-sequence').use(gulp);
+
+const noStack = function (done) {
+  return function (err) {
+    if (err) {
+      err.showStack = false;
+      done(err);
+    } else {
+      done();
+    }
+  };
+};
+
+gulp.task('test', function (done) {
+  runSequence('semistandard-lint', 'mocha-test', noStack(done));
 });
 
-gulp.task('tests', () =>
-  gulp.src(tests, { read: false })
-    .pipe(mocha({
-      require: ['./test/setup.js'],
-      reporter: CI ? 'spec' : 'nyan'
-    }))
-);
+// Watch meta-task.
+const watch = require('gulp-watch');
+const batch = require('gulp-batch');
 
-gulp.task('semistandard', () =>
-  gulp.src(sources.concat(tests))
+gulp.task('watch', function () {
+  watch(all, { ignoreInitial: false }, batch(function (events, done) {
+    gulp.start('test', done);
+  }));
+});
+
+// Semistandard-based linting task.
+const semistandard = require('gulp-semistandard');
+
+gulp.task('semistandard-lint', function () {
+  return gulp.src(all.concat('./gulpfile.js'))
     .pipe(semistandard())
     .pipe(semistandard.reporter('default', {
       breakOnError: true,
       quiet: true
-    }))
-);
+    }));
+});
 
-gulp.task('watch', function() {
-  gulp.watch(sources.concat(tests), ['tests', 'semistandard']);
+// Mocha-based testing task.
+const mocha = require('gulp-mocha');
+
+gulp.task('mocha-test', function () {
+  return gulp.src(globs.tests, { read: false })
+    .pipe(mocha({
+      require: globs.testsSetup,
+      reporter: CI ? 'spec' : 'nyan'
+    }));
 });


### PR DESCRIPTION
- Restructured using a more generalized, reuseable, and commented approach.
- Ensured that the linting and unit testing tasks executed in series to (1) avoid output being muddled and (2) properly handle errors surfacing to gulp.
- Cleaned up error output to minimize duplicate and/or useless information.

TODO: Consider replacing run-sequence with a construct that forces the running of both linting and unit testing regardless if either produces an error, while still surfacing errors so the exit code is correct for integration with Travis CI.