### PR TITLE
Update test runner.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "gulp-semistandard": "^1.0.0",
     "gulp-watch": "^4.3.11",
     "mocha": "^3.2.0",
-    "run-sequence": "^1.2.2",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0"
   }


### PR DESCRIPTION
- Added functionality to run a sequence of tests without stopping for errors.
- Removed reference to `run-sequence`.

NOTE: This addresses the TODO item from #19.  `run-sequence` stops executing at the first error.  However, that meant that a linter error would prevent the `mocha` unit tests from running.  This solution runs both the linter and testing tasks regardless of errors.  Though, any error is still reported up through gulp so that the exit code is correct, ensuring proper interaction with CI.