### PR TITLE
An attempt at a better regex for splitMessage

### DIFF
--- a/lib/avoid5-reddit.js
+++ b/lib/avoid5-reddit.js
@@ -66,7 +66,7 @@ const stripMentions = function (text) {
  /**
   * Does a Markdown quote on all the lines.
   *
-  * @param text  The text to qote.
+  * @param text  The text to quote.
   */
 const quote = function (text) {
   const regex = /\r?\n|\r/g;

--- a/lib/avoid5.js
+++ b/lib/avoid5.js
@@ -60,12 +60,12 @@ exports.mask = function (text) {
 };
 
 /**
- * Gets only the words surrounding the offending word, and returns an array of them.
+ * Gets offending words, and returns an array of them.
  *
  * @param text  The text to split.
  */
 exports.splitMessage = function (text) {
-  const regex = /\S*?■\S*/g;
+  const regex = /[\w'’]*?■[\w'’]*/g;
   return text.match(regex);
 };
 


### PR DESCRIPTION
The expression I replaced would match punctuation around words. [Example](https://www.reddit.com/r/AVoid5/comments/fqcsxv/avoid_5/flrfiak/?context=3)

The new expression won't do that. The only thing it won't accommodate is fancy single quotes.

This is my first pull request, so if I've done something that doesn't follow best practices please let me know! I just wanted to help somehow.